### PR TITLE
getTables() and smallint support in SqlMigrations class

### DIFF
--- a/src/Adamkearsley/ConvertMigrations/SqlMigrations.php
+++ b/src/Adamkearsley/ConvertMigrations/SqlMigrations.php
@@ -17,7 +17,7 @@ class SqlMigrations
  
     private static function getTables()
     {
-        return DB::select('SELECT table_name FROM information_schema.tables WHERE table_schema="' . self::$database . '"');
+        return DB::select('SELECT table_name FROM information_schema.tables WHERE Table_Type="'."BASE TABLE".'" and table_schema="' . self::$database . '"');
     }
  
     private static function getTableDescribes($table)
@@ -169,6 +169,9 @@ public function down()
                         break;
                     case 'bigint' :
                         $method = 'bigInteger';
+                        break;
+                    case 'samllint' :
+                        $method = 'smallInteger';
                         break;
                     case 'char' :
                     case 'varchar' :


### PR DESCRIPTION
the function getTables() return tables and views also by adding "Tabletype='base table'" now it only get the tables with out views. And also added the small int datatype support.